### PR TITLE
Fixing Ubuntu 22.04 support with Advanced and Standard modes.

### DIFF
--- a/install-panel.sh
+++ b/install-panel.sh
@@ -197,7 +197,6 @@ function check_os_comp {
     fi
   elif [ "$OS" == "debian" ]; then
     PHP_SOCKET="/run/php/php8.1-fpm.sock"
-    CONFIGURE_UFW=true
     if [ "$OS_VER_MAJOR" == "9" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "10" ]; then
@@ -207,7 +206,6 @@ function check_os_comp {
     fi
   elif [ "$OS" == "centos" ]; then
     PHP_SOCKET="/var/run/php-fpm/pterodactyl.sock"
-    CONFIGURE_FIREWALL=true
     if [ "$OS_VER_MAJOR" == "7" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "8" ]; then

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -185,15 +185,19 @@ function detect_distro {
 function check_os_comp {
   if [ "$OS" == "ubuntu" ]; then
     PHP_SOCKET="/run/php/php8.1-fpm.sock"
+    CONFIGURE_UFW=true
     if [ "$OS_VER_MAJOR" == "18" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "20" ]; then
+      SUPPORTED=true
+    elif [ "$OS_VER_MAJOR" == "22" ]; then
       SUPPORTED=true
     else
       SUPPORTED=false
     fi
   elif [ "$OS" == "debian" ]; then
     PHP_SOCKET="/run/php/php8.1-fpm.sock"
+    CONFIGURE_UFW=true
     if [ "$OS_VER_MAJOR" == "9" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "10" ]; then
@@ -203,6 +207,7 @@ function check_os_comp {
     fi
   elif [ "$OS" == "centos" ]; then
     PHP_SOCKET="/var/run/php-fpm/pterodactyl.sock"
+    CONFIGURE_FIREWALL=true
     if [ "$OS_VER_MAJOR" == "7" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "8" ]; then
@@ -223,7 +228,6 @@ function check_os_comp {
     exit 1
   fi
 }
-
 #################################
 ## main installation functions ##
 #################################

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -185,7 +185,6 @@ function detect_distro {
 function check_os_comp {
   if [ "$OS" == "ubuntu" ]; then
     PHP_SOCKET="/run/php/php8.1-fpm.sock"
-    CONFIGURE_UFW=true
     if [ "$OS_VER_MAJOR" == "18" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "20" ]; then

--- a/install-standard.sh
+++ b/install-standard.sh
@@ -182,15 +182,19 @@ function detect_distro {
 function check_os_comp {
   if [ "$OS" == "ubuntu" ]; then
     PHP_SOCKET="/run/php/php8.1-fpm.sock"
+    CONFIGURE_UFW=true
     if [ "$OS_VER_MAJOR" == "18" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "20" ]; then
+      SUPPORTED=true
+    elif [ "$OS_VER_MAJOR" == "22" ]; then
       SUPPORTED=true
     else
       SUPPORTED=false
     fi
   elif [ "$OS" == "debian" ]; then
     PHP_SOCKET="/run/php/php8.1-fpm.sock"
+    CONFIGURE_UFW=true
     if [ "$OS_VER_MAJOR" == "9" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "10" ]; then
@@ -200,6 +204,7 @@ function check_os_comp {
     fi
   elif [ "$OS" == "centos" ]; then
     PHP_SOCKET="/var/run/php-fpm/pterodactyl.sock"
+    CONFIGURE_FIREWALL=true
     if [ "$OS_VER_MAJOR" == "7" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "8" ]; then
@@ -220,7 +225,6 @@ function check_os_comp {
     exit 1
   fi
 }
-
 #################################
 ## main installation functions ##
 #################################

--- a/install-standard.sh
+++ b/install-standard.sh
@@ -182,7 +182,6 @@ function detect_distro {
 function check_os_comp {
   if [ "$OS" == "ubuntu" ]; then
     PHP_SOCKET="/run/php/php8.1-fpm.sock"
-    CONFIGURE_UFW=true
     if [ "$OS_VER_MAJOR" == "18" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "20" ]; then
@@ -194,7 +193,6 @@ function check_os_comp {
     fi
   elif [ "$OS" == "debian" ]; then
     PHP_SOCKET="/run/php/php8.1-fpm.sock"
-    CONFIGURE_UFW=true
     if [ "$OS_VER_MAJOR" == "9" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "10" ]; then

--- a/install-standard.sh
+++ b/install-standard.sh
@@ -202,7 +202,6 @@ function check_os_comp {
     fi
   elif [ "$OS" == "centos" ]; then
     PHP_SOCKET="/var/run/php-fpm/pterodactyl.sock"
-    CONFIGURE_FIREWALL=true
     if [ "$OS_VER_MAJOR" == "7" ]; then
       SUPPORTED=true
     elif [ "$OS_VER_MAJOR" == "8" ]; then


### PR DESCRIPTION
[install-panel.sh](https://github.com/ForestRacks/PteroInstaller/blob/main/install-panel.sh) and [install-standard.sh](https://github.com/ForestRacks/PteroInstaller/blob/main/install-standard.sh) hadn't been updated to reflect updates to the installer, shown in other files.